### PR TITLE
Expose the matched route pattern in the request extensions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub struct RouteBuilder {
 }
 
 #[derive(Clone)]
-struct RoutePattern(String);
+struct RoutePattern(&'static str);
 
 pub struct WrappedHandler {
     pattern: RoutePattern,
@@ -48,7 +48,7 @@ impl RouteBuilder {
     pub fn map<'a, H: Handler>(
         &'a mut self,
         method: Method,
-        pattern: &str,
+        pattern: &'static str,
         handler: H,
     ) -> &'a mut RouteBuilder {
         {
@@ -57,7 +57,7 @@ impl RouteBuilder {
                 Entry::Vacant(e) => e.insert(Router::new()),
             };
             let wrapped_handler = WrappedHandler {
-                pattern: RoutePattern(pattern.to_string()),
+                pattern: RoutePattern(pattern),
                 handler: Box::new(handler)
             };
             router.add(pattern, wrapped_handler);
@@ -65,23 +65,23 @@ impl RouteBuilder {
         self
     }
 
-    pub fn get<'a, H: Handler>(&'a mut self, pattern: &str, handler: H) -> &'a mut RouteBuilder {
+    pub fn get<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
         self.map(Method::GET, pattern, handler)
     }
 
-    pub fn post<'a, H: Handler>(&'a mut self, pattern: &str, handler: H) -> &'a mut RouteBuilder {
+    pub fn post<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
         self.map(Method::POST, pattern, handler)
     }
 
-    pub fn put<'a, H: Handler>(&'a mut self, pattern: &str, handler: H) -> &'a mut RouteBuilder {
+    pub fn put<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
         self.map(Method::PUT, pattern, handler)
     }
 
-    pub fn delete<'a, H: Handler>(&'a mut self, pattern: &str, handler: H) -> &'a mut RouteBuilder {
+    pub fn delete<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
         self.map(Method::DELETE, pattern, handler)
     }
 
-    pub fn head<'a, H: Handler>(&'a mut self, pattern: &str, handler: H) -> &'a mut RouteBuilder {
+    pub fn head<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
         self.map(Method::HEAD, pattern, handler)
     }
 }
@@ -250,7 +250,7 @@ mod tests {
         let mut res = vec![];
         res.push(req.params()["id"].clone());
         res.push(format!("{:?}", req.method()));
-        res.push(req.extensions().find::<RoutePattern>().unwrap().0.clone());
+        res.push(req.extensions().find::<RoutePattern>().unwrap().0.to_string());
 
         let bytes = res.join(", ").into_bytes();
         Response::builder().body(Body::from_vec(bytes))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,12 @@ pub struct WrappedHandler {
     handler: Box<dyn Handler>,
 }
 
+impl conduit::Handler for WrappedHandler {
+    fn call(&self, request: &mut dyn RequestExt) -> HandlerResult {
+        self.handler.call(request)
+    }
+}
+
 #[derive(Debug)]
 pub struct RouterError(String);
 
@@ -104,7 +110,7 @@ impl conduit::Handler for RouteBuilder {
             extensions.insert(m.params.clone());
         }
 
-        (*m.handler.handler).call(request)
+        (*m.handler).call(request)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,30 +64,50 @@ impl RouteBuilder {
             };
             let wrapped_handler = WrappedHandler {
                 pattern: RoutePattern(pattern),
-                handler: Box::new(handler)
+                handler: Box::new(handler),
             };
             router.add(pattern, wrapped_handler);
         }
         self
     }
 
-    pub fn get<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
+    pub fn get<'a, H: Handler>(
+        &'a mut self,
+        pattern: &'static str,
+        handler: H,
+    ) -> &'a mut RouteBuilder {
         self.map(Method::GET, pattern, handler)
     }
 
-    pub fn post<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
+    pub fn post<'a, H: Handler>(
+        &'a mut self,
+        pattern: &'static str,
+        handler: H,
+    ) -> &'a mut RouteBuilder {
         self.map(Method::POST, pattern, handler)
     }
 
-    pub fn put<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
+    pub fn put<'a, H: Handler>(
+        &'a mut self,
+        pattern: &'static str,
+        handler: H,
+    ) -> &'a mut RouteBuilder {
         self.map(Method::PUT, pattern, handler)
     }
 
-    pub fn delete<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
+    pub fn delete<'a, H: Handler>(
+        &'a mut self,
+        pattern: &'static str,
+        handler: H,
+    ) -> &'a mut RouteBuilder {
         self.map(Method::DELETE, pattern, handler)
     }
 
-    pub fn head<'a, H: Handler>(&'a mut self, pattern: &'static str, handler: H) -> &'a mut RouteBuilder {
+    pub fn head<'a, H: Handler>(
+        &'a mut self,
+        pattern: &'static str,
+        handler: H,
+    ) -> &'a mut RouteBuilder {
         self.map(Method::HEAD, pattern, handler)
     }
 }
@@ -256,7 +276,13 @@ mod tests {
         let mut res = vec![];
         res.push(req.params()["id"].clone());
         res.push(format!("{:?}", req.method()));
-        res.push(req.extensions().find::<RoutePattern>().unwrap().0.to_string());
+        res.push(
+            req.extensions()
+                .find::<RoutePattern>()
+                .unwrap()
+                .0
+                .to_string(),
+        );
 
         let bytes = res.join(", ").into_bytes();
         Response::builder().body(Body::from_vec(bytes))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub struct RouteBuilder {
 }
 
 #[derive(Clone, Copy)]
-struct RoutePattern(&'static str);
+pub struct RoutePattern(&'static str);
 
 pub struct WrappedHandler {
     pattern: RoutePattern,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub struct RouteBuilder {
     routers: HashMap<Method, Router<WrappedHandler>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 struct RoutePattern(&'static str);
 
 pub struct WrappedHandler {
@@ -100,7 +100,7 @@ impl conduit::Handler for RouteBuilder {
 
         {
             let extensions = request.mut_extensions();
-            extensions.insert(m.handler.pattern.clone());
+            extensions.insert(m.handler.pattern);
             extensions.insert(m.params.clone());
         }
 


### PR DESCRIPTION
This allows us to add the `RoutePattern` to diagnostic messages to e.g. group up Sentry reports