### PR TITLE
Add caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Cache cargo build
+        uses: actions/cache@main
+        with:
+          path: target
+          key: ${{ runner.os }}-lint-target-${{ steps.rustc.outputs.version }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-lint-target-${{ steps.rustc.outputs.version }}-
+
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
@@ -69,6 +77,14 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+
+      - name: Cache cargo build
+        uses: actions/cache@main
+        with:
+          path: target
+          key: ${{ runner.os }}-target-${{ steps.rustc.outputs.version }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-target-${{ steps.rustc.outputs.version }}-
 
       - name: cargo build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: '0 3 * * *' # daily, at 3am
+    - cron: '0 3 * * 0' # weekly, Sunday at 3am
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - id: toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
@@ -36,9 +37,9 @@ jobs:
         uses: actions/cache@main
         with:
           path: target
-          key: ${{ runner.os }}-lint-target-${{ steps.rustc.outputs.version }}-${{ github.run_id }}
+          key: ${{ runner.os }}-lint-target-${{ steps.toolchain.outputs.rustc }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-lint-target-${{ steps.rustc.outputs.version }}-
+            ${{ runner.os }}-lint-target-${{ steps.toolchain.outputs.rustc }}-
 
       - name: cargo fmt
         uses: actions-rs/cargo@v1
@@ -62,7 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - id: toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
@@ -82,9 +84,9 @@ jobs:
         uses: actions/cache@main
         with:
           path: target
-          key: ${{ runner.os }}-target-${{ steps.rustc.outputs.version }}-${{ github.run_id }}
+          key: ${{ runner.os }}-target-${{ steps.toolchain.outputs.rustc }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-target-${{ steps.rustc.outputs.version }}-
+            ${{ runner.os }}-target-${{ steps.toolchain.outputs.rustc }}-
 
       - name: cargo build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Cache cargo registry and git deps
+        uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+          key: ${{ runner.os }}-cargo-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
@@ -49,6 +59,16 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+
+      - name: Cache cargo registry and git deps
+        uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+          key: ${{ runner.os }}-cargo-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: cargo build
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
This reduces the cron schedule to weekly and adds caching.

Because we do not check in a `Cargo.lock` file, dependencies may be updated at any time. Therefore, each workflow run gets a unique cache key based on `github.run_id`.

r? @Turbo87 