### PR TITLE
Avoid some allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["wycats@gmail.com"]
 license = "MIT"
 description = "Router middleware for conduit based on route-recognizer"
 repository = "https://github.com/conduit-rust/conduit-router"
+edition = "2018"
 
 [dependencies]
 conduit = "0.9.0-alpha.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,16 +281,31 @@ mod tests {
     }
 
     #[test]
-    fn nonexistent_route() {
+    fn path_not_found() {
         lazy_static::initialize(&TRACING);
 
         let router = test_router();
         let mut req = RequestSentinel::new(Method::POST, "/nonexistent");
-        router.call(&mut req).err().expect("No response");
+        let err = router.call(&mut req).err().unwrap();
+
+        assert_eq!(err.to_string(), super::NOT_FOUND);
+    }
+
+    #[test]
+    fn unknown_method() {
+        lazy_static::initialize(&TRACING);
+
+        let router = test_router();
+        let mut req = RequestSentinel::new(Method::DELETE, "/posts/1");
+        let err = router.call(&mut req).err().unwrap();
+
+        assert_eq!(err.to_string(), super::UNKNOWN_METHOD);
     }
 
     #[test]
     fn catch_all() {
+        lazy_static::initialize(&TRACING);
+
         let mut router = RouteBuilder::new();
         router.get("/*", test_handler);
 


### PR DESCRIPTION
This switches to static error messages. This avoids the allocation and formatting of a `String` which crates.io will throw away.

Additionally, `mem::swap` is used to avoid an unnecessary clone of the `BTreeMap` inside `Params`.